### PR TITLE
Use crates for targets from git

### DIFF
--- a/httparse/Cargo.toml
+++ b/httparse/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 publish = false
 
 [dependencies]
-httparse = "1.2"
+httparse = { git = "https://github.com/seanmonstar/httparse" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/mp4parse/Cargo.toml
+++ b/mp4parse/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 publish = false
 
 [dependencies]
-mp4parse = "0.7"
+mp4parse = { git = "https://github.com/mozilla/mp4parse-rust" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/quick-xml/Cargo.toml
+++ b/quick-xml/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 publish = false
 
 [dependencies]
-quick-xml = "0.6"
+quick-xml = { git = "https://github.com/tafia/quick-xml" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/serde_json/Cargo.toml
+++ b/serde_json/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 publish = false
 
 [dependencies]
-serde_json = "0.9"
+serde_json = { git = "https://github.com/serde-rs/json" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]

--- a/tar/Cargo.toml
+++ b/tar/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 publish = false
 
 [dependencies]
-tar = "0.4"
+tar = { git = "https://github.com/alexcrichton/tar-rs" }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 
 [[bin]]


### PR DESCRIPTION
This has a few advantages:

a) It enables continous fuzzing
b) It means you don't need to update them on every release
c) It lets you easily validate fixes as upstream commits them