### PR TITLE
Add fuzz target for RustCrypto hashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crypto-hashes",
     "cssparser",
     "httparse",
     "flac",

--- a/crypto-hashes/Cargo.toml
+++ b/crypto-hashes/Cargo.toml
@@ -1,0 +1,93 @@
+[package]
+name = "crypto-hashes-targets"
+version = "0.0.0"
+publish = false
+
+[dependencies]
+blake2 = { git = "https://github.com/RustCrypto/hashes" }
+gost94 = { git = "https://github.com/RustCrypto/hashes" }
+groestl = { git = "https://github.com/RustCrypto/hashes" }
+md2 = { git = "https://github.com/RustCrypto/hashes" }
+md4 = { git = "https://github.com/RustCrypto/hashes" }
+md5 = { git = "https://github.com/RustCrypto/hashes" }
+ripemd160 = { git = "https://github.com/RustCrypto/hashes" }
+sha1 = { git = "https://github.com/RustCrypto/hashes" }
+sha2 = { git = "https://github.com/RustCrypto/hashes" }
+sha3 = { git = "https://github.com/RustCrypto/hashes" }
+streebog = { git = "https://github.com/RustCrypto/hashes" }
+whirlpool = { git = "https://github.com/RustCrypto/hashes" }
+libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+generic-array = "0.7"
+
+[[bin]]
+name = "blake2b"
+path = "blake2b.rs"
+
+[[bin]]
+name = "blake2s"
+path = "blake2s.rs"
+
+[[bin]]
+name = "gost94"
+path = "gost94.rs"
+
+[[bin]]
+name = "groestl_256"
+path = "groestl_256.rs"
+
+[[bin]]
+name = "groestl_512"
+path = "groestl_512.rs"
+
+[[bin]]
+name = "md2"
+path = "md2.rs"
+
+[[bin]]
+name = "md4"
+path = "md4.rs"
+
+[[bin]]
+name = "md5"
+path = "md5.rs"
+
+[[bin]]
+name = "ripemd160"
+path = "ripemd160.rs"
+
+[[bin]]
+name = "sha1"
+path = "sha1.rs"
+
+[[bin]]
+name = "sha2_256"
+path = "sha2_256.rs"
+
+[[bin]]
+name = "sha2_512"
+path = "sha2_512.rs"
+
+[[bin]]
+name = "sha3_512"
+path = "sha3_512.rs"
+
+[[bin]]
+name = "sha3_keccak512"
+path = "sha3_keccak512.rs"
+
+[[bin]]
+name = "sha3_shake256"
+path = "sha3_shake256.rs"
+
+[[bin]]
+name = "streebog_256"
+path = "streebog_256.rs"
+
+[[bin]]
+name = "streebog_512"
+path = "streebog_512.rs"
+
+[[bin]]
+name = "whirlpool"
+path = "whirlpool.rs"
+

--- a/crypto-hashes/blake2b.rs
+++ b/crypto-hashes/blake2b.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate blake2;
+
+use blake2::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = blake2::Blake2b512::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/blake2s.rs
+++ b/crypto-hashes/blake2s.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate blake2;
+
+use blake2::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = blake2::Blake2s256::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/gost94.rs
+++ b/crypto-hashes/gost94.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate gost94;
+
+use gost94::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = gost94::Gost94Test::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/groestl_256.rs
+++ b/crypto-hashes/groestl_256.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate groestl;
+
+use groestl::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = groestl::Groestl256::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/groestl_512.rs
+++ b/crypto-hashes/groestl_512.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate groestl;
+
+use groestl::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = groestl::Groestl512::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/md2.rs
+++ b/crypto-hashes/md2.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate md2;
+
+use md2::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = md2::Md2::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/md4.rs
+++ b/crypto-hashes/md4.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate md4;
+
+use md4::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = md4::Md4::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/md5.rs
+++ b/crypto-hashes/md5.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate md5;
+
+use md5::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = md5::Md5::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/ripemd160.rs
+++ b/crypto-hashes/ripemd160.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate ripemd160;
+
+use ripemd160::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = ripemd160::Ripemd160::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/sha1.rs
+++ b/crypto-hashes/sha1.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate sha1;
+
+use sha1::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = sha1::Sha1::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/sha2_256.rs
+++ b/crypto-hashes/sha2_256.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate sha2;
+
+use sha2::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = sha2::Sha256::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/sha2_512.rs
+++ b/crypto-hashes/sha2_512.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate sha2;
+
+use sha2::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = sha2::Sha512::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/sha3_512.rs
+++ b/crypto-hashes/sha3_512.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate sha3;
+
+use sha3::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = sha3::Sha3_512::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/sha3_keccak512.rs
+++ b/crypto-hashes/sha3_keccak512.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate sha3;
+
+use sha3::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = sha3::Keccak512::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/sha3_shake256.rs
+++ b/crypto-hashes/sha3_shake256.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate sha3;
+extern crate generic_array;
+
+use sha3::Digest;
+use generic_array::typenum::U256;
+
+fuzz_target!(|data| {
+    let mut hasher = sha3::Shake256::<U256>::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/streebog_256.rs
+++ b/crypto-hashes/streebog_256.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate streebog;
+
+use streebog::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = streebog::Streebog256::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/streebog_512.rs
+++ b/crypto-hashes/streebog_512.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate streebog;
+
+use streebog::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = streebog::Streebog512::new();
+    hasher.input(data);
+    hasher.result();
+});
+

--- a/crypto-hashes/whirlpool.rs
+++ b/crypto-hashes/whirlpool.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate whirlpool;
+
+use whirlpool::Digest;
+
+fuzz_target!(|data| {
+    let mut hasher = whirlpool::Whirlpool::new();
+    hasher.input(data);
+    hasher.result();
+});
+


### PR DESCRIPTION
One note: it's probably worth to use non default `-max_len` parameter at least several block sizes of a hash. Related issue: rust-fuzz/cargo-fuzz#3