### PR TITLE
Add fuzz targets for lz4-compress crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 members = [
     "crypto-hashes",
     "cssparser",
-    "httparse",
     "flac",
+    "httparse",
+    "lz4-compress",
     "mp4parse",
     "pulldown-cmark",
     "quick-xml",

--- a/lz4-compress/Cargo.toml
+++ b/lz4-compress/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "lz4-compress-targets"
+version = "0.0.0"
+publish = false
+
+[dependencies]
+libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+lz4-compress = { git = "https://github.com/ticki/tfs" }
+
+[[bin]]
+name = "compress"
+path = "compress.rs"
+
+[[bin]]
+name = "decompress"
+path = "decompress.rs"

--- a/lz4-compress/compress.rs
+++ b/lz4-compress/compress.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate lz4_compress;
+
+fuzz_target!(|data: &[u8]| {
+    lz4_compress::compress(data);
+});

--- a/lz4-compress/decompress.rs
+++ b/lz4-compress/decompress.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate lz4_compress;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(_) = lz4_compress::decompress(data) {}
+});


### PR DESCRIPTION
Created just for fun, after I managed to get cargo fuzz to work on macOS (using a docker-machine VM running a container based on `jimmycuadra/rust` FYI).

Will let this for a few hours, and see if it finds anything :)

(Locally, I also added `-C opt-level=3` to `RUSTFLAGS` for what it's worth)