### PR TITLE
Add fuzz target for regex crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,12 @@
 members = [
     "crypto-hashes",
     "cssparser",
-    "httparse",
     "flac",
+    "httparse",
     "mp4parse",
     "pulldown-cmark",
     "quick-xml",
+    "regex",
     "serde_json",
     "tar",
     "xml-rs",

--- a/regex/Cargo.toml
+++ b/regex/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "regex-targets"
+version = "0.0.0"
+publish = false
+
+[dependencies]
+regex = { git = "https://github.com/rust-lang-nursery/regex" }
+libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+
+[[bin]]
+name = "is_match"
+path = "is_match.rs"

--- a/regex/is_match.rs
+++ b/regex/is_match.rs
@@ -1,0 +1,21 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate regex;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(data) = std::str::from_utf8(data) {
+        // split data into regular expression and actual input to search through
+        use std::cmp::max;
+        let len = data.chars().count();
+        let split_off_point = max(len / 5, 1) as usize;
+        let char_index = data.char_indices().nth(split_off_point);
+
+        if let Some((char_index, _)) = char_index {
+            let (pattern, input) = data.split_at(char_index);
+            if let Ok(re) = regex::Regex::new(pattern) {
+                re.is_match(input);
+            }
+        }
+    }
+});


### PR DESCRIPTION
It's just a target for `is_match` right now, but it extracts both the regex and the input string from the fuzz input data (without allocating fwiw). Might be interesting to add captures and more complex operations later on.

cf. #37