### PR TITLE
Do not send notifications to email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ install: cargo build --all --verbose
 script: echo ""
 sudo: required
 dist: trusty
+
+notifications: { email: false }


### PR DESCRIPTION
Since bors will already send failures to a PRs comment section,
it is useless for Travis to additionally send an email.