### PR TITLE
Add fuzz target for minidump.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "image",
     "iso8601",
     "lz4-compress",
+    "minidump",
     "mp4parse",
     "patch",
     "pikkr",

--- a/minidump/Cargo.toml
+++ b/minidump/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "minidump-targets"
+version = "0.0.0"
+publish = false
+
+[dependencies]
+libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+minidump = { git = "https://github.com/luser/rust-minidump.git" }
+
+[[bin]]
+name = "read"
+path = "read.rs"

--- a/minidump/read.rs
+++ b/minidump/read.rs
@@ -1,0 +1,12 @@
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate minidump;
+
+use minidump::Minidump;
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| {
+    let cursor = Cursor::new(data);
+    let _ = minidump::Minidump::read(cursor);
+});


### PR DESCRIPTION
Fixes https://github.com/rust-fuzz/targets/issues/94.