### PR TITLE
Add target for rustc syntax lexer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "regex",
     "ring",
     # "rustfmt",
+    "rustc-syntax",
     "semver",
     "serde_json",
     "serde_yaml",

--- a/rustc-syntax/Cargo.toml
+++ b/rustc-syntax/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rustc-syntax-targets"
+version = "0.0.0"
+publish = false
+
+[dependencies]
+libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+
+[[bin]]
+name = "lexer-read"
+path = "lexer-read.rs"

--- a/rustc-syntax/lexer-read.rs
+++ b/rustc-syntax/lexer-read.rs
@@ -1,0 +1,28 @@
+#![feature(rustc_private)]
+#![no_main]
+
+#[macro_use] extern crate libfuzzer_sys;
+extern crate syntax;
+extern crate syntax_pos;
+
+use std::path::PathBuf;
+use std::rc::Rc;
+use syntax::codemap::{CodeMap, FilePathMapping};
+use syntax::parse::{token, ParseSess};
+use syntax::parse::lexer::StringReader;
+
+fuzz_target!(|bytes: &[u8]| {
+    let s = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(..) => return,
+    };
+    let cm = Rc::new(CodeMap::new(FilePathMapping::empty()));
+    let sess = ParseSess::new(FilePathMapping::empty());
+    let fm = cm.new_filemap(PathBuf::from("silvasean.rs").into(), s.to_owned());
+    let mut lexer = StringReader::new(&sess, fm);
+    while let Ok(next) = lexer.try_next_token() {
+        if next.tok == token::Token::Eof {
+            return;
+        }
+    }
+});


### PR DESCRIPTION
Blocked on:

```
error: the linked panic runtime `panic_unwind` is not compiled with this crate's panic strategy `abort`
```