### PR TITLE
Add regex syntax target

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,6 +31,7 @@ proc-macro2 = { git = "https://github.com/alexcrichton/proc-macro2.git" }
 pulldown-cmark = { git = "https://github.com/google/pulldown-cmark.git" }
 quick-xml = { git = "https://github.com/tafia/quick-xml" }
 regex = { git = "https://github.com/rust-lang-nursery/regex" }
+regex-syntax = { git = "https://github.com/rust-lang-nursery/regex" }
 ring = { git = "https://github.com/briansmith/ring" }
 semver = { git = "https://github.com/steveklabnik/semver" }
 serde_json = { git = "https://github.com/serde-rs/json", features = ["arbitrary_precision"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -25,6 +25,7 @@ extern crate proc_macro2;
 extern crate pulldown_cmark;
 extern crate quick_xml;
 extern crate regex;
+extern crate regex_syntax;
 extern crate ring;
 extern crate semver;
 extern crate serde_json;
@@ -472,6 +473,13 @@ pub fn fuzz_quick_xml_read(data: &[u8]) {
             Ok(quick_xml::events::Event::Eof) | Err(..) => break,
             _ => buf.clear(),
         }
+    }
+}
+
+#[inline(always)]
+pub fn fuzz_regex_syntax(data: &[u8]) {
+    if let Ok(data) = std::str::from_utf8(data) {
+        let _ = regex_syntax::Parser::new().parse(data);
     }
 }
 


### PR DESCRIPTION
Add regex syntax target

Run it with `cargo run target regex_syntax`

Finds the following inputs that yield panics, some of which are also
mentioned in [1]:

- `b"(?m)?"`
- `b"(?i)?i\x0e"`
- `b"CBh~62\x17Y((?i))??i\x0e"`
- `b"(?m)?90"`
- `b"(?i)?"`

[1]: https://github.com/rust-lang/regex/issues/465