### PR TITLE
Fix fuzz targets

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -388,8 +388,7 @@ pub fn fuzz_obj_load(data: &[u8]) {
     use std::io::Cursor;
 
     let cursor = Cursor::new(data);
-
-    let _: obj::Obj = obj::load_obj(cursor).unwrap();
+    let _: Result<obj::Obj, obj::ObjError> = obj::load_obj(cursor);
 }
 
 #[inline(always)]
@@ -398,9 +397,9 @@ pub fn fuzz_lewton_read(data: &[u8]) {
 
     let cursor = Cursor::new(data);
 
-    let mut reader = lewton::inside_ogg::OggStreamReader::new(cursor).unwrap();
-
-    while let Some(_) = reader.read_dec_packet().unwrap() {}
+    if let Ok(mut reader) = lewton::inside_ogg::OggStreamReader::new(cursor) {
+        while let Ok(Some(_)) = reader.read_dec_packet() {}
+    }
 }
 
 #[inline(always)]


### PR DESCRIPTION
I wrongly added `.unwrap()` to some of the fuzz targets I committed a while back. They would produce false positives so I removed them.

Thanks to @Shnatsel in #125 for pointing this out.