### PR TITLE
Fix running AFL from the CLI

### DIFF
--- a/cli.rs
+++ b/cli.rs
@@ -237,7 +237,7 @@ fn run_honggfuzz(target: &str, timeout: Option<i32>) -> Result<(), Error> {
         .env("HFUZZ_RUN_ARGS", &args)
         .current_dir(&dir)
         .spawn()
-        .context(format!("error starting {:?} to runn {}", fuzzer, target))?
+        .context(format!("error starting {:?} to run {}", fuzzer, target))?
         .wait()
         .context(format!(
             "error while waiting for {:?} running {}",
@@ -258,16 +258,28 @@ fn run_afl(target: &str, _timeout: Option<i32>) -> Result<(), Error> {
     let seed_dir = create_seed_dir(&target)?;
     let corpus_dir = create_corpus_dir(&dir, target)?;
 
+    let build_cmd = Command::new("cargo")
+        .args(&["afl", "build", "--release", "--bin", target])
+        .current_dir(&dir)
+        .spawn()
+        .context(format!("error starting build for {:?} of {}", fuzzer, target))?
+        .wait()
+        .context(format!("error while waiting for build for {:?} of {}", fuzzer, target))?;
+
+    if !build_cmd.success() {
+        Err(FuzzerQuit)?;
+    }
+
     let fuzzer_bin = Command::new("cargo")
         .args(&["afl", "fuzz"])
         .arg("-i")
         .arg(&seed_dir)
         .arg("-o")
         .arg(&corpus_dir)
-        .args(&["--", &format!("target/release/{}", target)])
+        .args(&["--", &format!("../target/release/{}", target)])
         .current_dir(&dir)
         .spawn()
-        .context(format!("error starting {:?} to runn {}", fuzzer, target))?
+        .context(format!("error starting {:?} to run {}", fuzzer, target))?
         .wait()
         .context(format!(
             "error while waiting for {:?} running {}",
@@ -331,7 +343,7 @@ fn run_libfuzzer(target: &str, timeout: Option<i32>) -> Result<(), Error> {
         .env("ASAN_OPTIONS", &asan_options)
         .current_dir(&dir)
         .spawn()
-        .context(format!("error starting {:?} to runn {}", fuzzer, target))?
+        .context(format!("error starting {:?} to run {}", fuzzer, target))?
         .wait()
         .context(format!(
             "error while waiting for {:?} running {}",

--- a/cli.rs
+++ b/cli.rs
@@ -8,6 +8,7 @@ extern crate failure;
 extern crate regex;
 
 use std::env;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -270,10 +271,17 @@ fn run_afl(target: &str, _timeout: Option<i32>) -> Result<(), Error> {
         Err(FuzzerQuit)?;
     }
 
+    let queue_dir = corpus_dir.join("queue");
+    let input_arg: &OsStr = if queue_dir.is_dir() && fs::read_dir(queue_dir)?.next().is_some() {
+        "-".as_ref()
+    } else {
+        seed_dir.as_ref()
+    };
+
     let fuzzer_bin = Command::new("cargo")
         .args(&["afl", "fuzz"])
         .arg("-i")
-        .arg(&seed_dir)
+        .arg(&input_arg)
         .arg("-o")
         .arg(&corpus_dir)
         .args(&["--", &format!("../target/release/{}", target)])


### PR DESCRIPTION
Running with `--target Afl` wasn't working for me; here are the fixes I needed for it.

* Run `cargo afl build` first, before invoking the fuzzer
* Fix the path to the binary to refer to the workspace's target directory
* On subsequent runs of a fuzzer, don't pass an input directory, as AFL would either clobber the output directory or refuse to start