### PR TITLE
AFL timeout

### DIFF
--- a/cli.rs
+++ b/cli.rs
@@ -288,6 +288,8 @@ fn run_afl(target: &str, timeout: Option<i32>) -> Result<(), Error> {
         .arg(&input_arg)
         .arg("-o")
         .arg(&corpus_dir)
+        .arg("-T")
+        .arg(target)
         .args(&["--", &format!("../target/release/{}", target)])
         .current_dir(&dir);
     let fuzzer_status = fuzzer_cmd

--- a/cli.rs
+++ b/cli.rs
@@ -27,7 +27,7 @@ enum Cli {
         #[structopt(short = "q", long = "filter")]
         filter: Option<String>,
         /// Set timeout per target
-        #[structopt(short = "t", long = "timeout", default_value = "10")]
+        #[structopt(short = "t", long = "timeout", default_value = "30")]
         timeout: i32,
         // Run until the end of time (or Ctrl+C)
         #[structopt(short = "i", long = "infinite")]


### PR DESCRIPTION
This closes #107, and depends on rust-fuzz/afl.rs#162.

I also made the current target display in AFL's output, and dialed the default time limit up to 30 seconds. (ten seconds is sometimes barely enough for AFL to get through its preparation when resuming)